### PR TITLE
Fix `reference to packed field is unaligned`

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -184,9 +184,8 @@ impl TryFrom<sys::uhid_event> for OutputEvent {
         if let Some(event_type) = to_uhid_event_type(event.type_) {
             match event_type {
                 sys::uhid_event_type_UHID_START => Ok(unsafe {
-                    let payload = &event.u.start;
                     OutputEvent::Start {
-                        dev_flags: BitFlags::from_bits_truncate(payload.dev_flags)
+                        dev_flags: BitFlags::from_bits_truncate(event.u.start.dev_flags)
                             .iter()
                             .collect(),
                     }


### PR DESCRIPTION
error: reference to packed field is unaligned
   --> src/codec.rs:187:35
    |
187 |                     let payload = &event.u.start;
    |                                   ^^^^^^^^^^^^^^
    |
    = note: `#[deny(unaligned_references)]` on by default
    = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
    = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
    = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
    = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)