### PR TITLE
Fix future-incompatibilities warning

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -184,9 +184,10 @@ impl TryFrom<sys::uhid_event> for OutputEvent {
         if let Some(event_type) = to_uhid_event_type(event.type_) {
             match event_type {
                 sys::uhid_event_type_UHID_START => Ok(unsafe {
-                    let payload = &event.u.start;
+                    //let payload = &event.u.start;
+                    let dev_flags = event.u.start.dev_flags;
                     OutputEvent::Start {
-                        dev_flags: BitFlags::from_bits_truncate(payload.dev_flags)
+                        dev_flags: BitFlags::from_bits_truncate(dev_flags)
                             .iter()
                             .collect(),
                     }


### PR DESCRIPTION
This PR fixes a warning about future-incompatibility.

Details of the warning:

> warning: reference to packed field is unaligned
>    --> /home/felfert/.cargo/registry/src/github.com-1ecc6299db9ec823/uhid-virt-0.0.5/src/codec.rs:187:35
>     |
> 187 |                     let payload = &event.u.start;
>     |                                   ^^^^^^^^^^^^^^
>     |
>     = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in a future release!
>     = note: for more information, see issue #82523 <https://github.com/rust-lang/rust/issues/82523>
>     = note: fields of packed structs are not properly aligned, and creating a misaligned reference is undefined behavior (even if that reference is never dereferenced)
>     = help: copy the field contents to a local variable, or replace the reference with a raw pointer and use `read_unaligned`/`write_unaligned` (loads and stores via `*p` must be properly aligned even when using raw pointers)
>     = note: `#[allow(unaligned_references)]` on by default