### PR TITLE
Update uhidrs-sys for upcoming bindgen/nom incompatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,6 @@ doc = true
 test = true
 
 [dependencies]
-uhidrs-sys = "1.0.0"
+uhidrs-sys = "1.0.2"
 enumflags2 = "^0.7.7"
 libc = "^0.2.0"


### PR DESCRIPTION
warning: the following packages contain code that will be rejected by a future version of Rust: bindgen v0.54.0, nom v5.1.2
note: to see what the problems were, use the option `--future-incompat-report`, or run `cargo report future-incompatibilities --id 1`

(thanks for merging my earlier changes!)

This warning comes from a recently nightly

```
cargo --version
cargo 1.71.0-nightly (d0a4cbcee 2023-04-16)
rustc --version
rustc 1.71.0-nightly (8bdcc62cb 2023-04-20)
```