### PR TITLE
fix const names

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -165,7 +165,7 @@ impl<'a> From<InputEvent<'a>> for sys::uhid_event {
                     .enumerate()
                     .for_each(|(i, x)| payload.data[i] = *x);
                 payload.size = data.len() as u16;
-                payload.rtype = sys::hid_report_type_HID_OUTPUT_REPORT as u8;
+                payload.rtype = sys::uhid_report_type_UHID_OUTPUT_REPORT as u8;
             }
             InputEvent::OutputEv { type_, code, value } => {
                 event.type_ = sys::uhid_event_type___UHID_LEGACY_OUTPUT_EV;
@@ -195,7 +195,7 @@ impl<'a> From<InputEvent<'a>> for sys::uhid_event {
                 let payload = unsafe { &mut event.u.feature };
                 payload.id = id;
                 payload.rnum = report_num;
-                payload.rtype = sys::hid_report_type_HID_INPUT_REPORT as u8;
+                payload.rtype = sys::uhid_report_type_UHID_INPUT_REPORT as u8;
             }
             InputEvent::FeatureAnswer { err, id, data, .. } => {
                 event.type_ = sys::uhid_event_type_UHID_GET_REPORT_REPLY;
@@ -220,7 +220,7 @@ impl<'a> From<InputEvent<'a>> for sys::uhid_event {
                 payload.size = data.len() as u16;
                 payload.id = id;
                 payload.rnum = report_num;
-                payload.rtype = sys::hid_report_type_HID_INPUT_REPORT as u8;
+                payload.rtype = sys::uhid_report_type_UHID_INPUT_REPORT as u8;
             }
         };
 


### PR DESCRIPTION
Update to the report types to use the UHID const (enum in the underlying C code) vs the HID const. Ultimately, the Rust payload.rtype is set to the same u8 value either way but this fixes an issue found during builds.

When compiling on Ubuntu 22.04 this would throw an error as bindgen wouldn't add in these HID constants during the generation in uhidrs-sys. ```error[E0425]: cannot find value `hid_report_type_HID_OUTPUT_REPORT` in crate `sys` ```
I also tested on Fedora Linux 40 and bindgen had no such issue, working fine with or without this fix. 