### PR TITLE
Allow arbitrary changes to the outgoing packet

### DIFF
--- a/src/codec.rs
+++ b/src/codec.rs
@@ -295,7 +295,7 @@ impl TryFrom<sys::uhid_event> for OutputEvent {
                     OutputEvent::GetReport {
                         id: payload.id,
                         report_number: payload.rnum,
-                        report_type: mem::transmute(payload.rtype),
+                        report_type: mem::transmute::<u8, ReportType>(payload.rtype),
                     }
                 }),
                 sys::uhid_event_type_UHID_SET_REPORT => Ok(unsafe {
@@ -303,7 +303,7 @@ impl TryFrom<sys::uhid_event> for OutputEvent {
                     OutputEvent::SetReport {
                         id: payload.id,
                         report_number: payload.rnum,
-                        report_type: mem::transmute(payload.rtype),
+                        report_type: mem::transmute::<u8, ReportType>(payload.rtype),
                         data: slice::from_raw_parts(
                             &payload.data[0] as *const u8,
                             payload.size as usize,

--- a/src/uhid_device.rs
+++ b/src/uhid_device.rs
@@ -45,7 +45,22 @@ impl<T: Read + Write> UHIDDevice<T> {
         err: u16,
         data: Vec<u8>,
     ) -> io::Result<usize> {
-        let event: [u8; UHID_EVENT_SIZE] = InputEvent::GetReportReply { id, err, data }.into();
+        self.write_transformed_get_report_reply(id, err, data, |_| {})
+    }
+
+    /// Write a GetReportReply, only use in reponse to a read GetReport event
+    pub fn write_transformed_get_report_reply<F>
+    (
+        &mut self,
+        id: u32,
+        err: u16,
+        data: Vec<u8>,
+        fun: F
+    )  -> io::Result<usize>
+    where
+        F: Fn(&mut [u8]) -> (){
+        let mut event: [u8; UHID_EVENT_SIZE] = InputEvent::GetReportReply { id, err, data }.into();
+        fun(&mut event);
         self.handle.write(&event)
     }
 

--- a/src/uhid_device.rs
+++ b/src/uhid_device.rs
@@ -33,7 +33,7 @@ impl<T: Read + Write> UHIDDevice<T> {
 
     pub fn write_transformed<F>(&mut self, data: &[u8], fun: F) -> io::Result<usize>
     where
-        F: Fn(&mut [u8]) -> (),
+        F: Fn(&mut [u8]),
     {
         let mut event: [u8; UHID_EVENT_SIZE] = InputEvent::Input { data }.into();
         fun(&mut event);
@@ -65,7 +65,7 @@ impl<T: Read + Write> UHIDDevice<T> {
         fun: F,
     ) -> io::Result<usize>
     where
-        F: Fn(&mut [u8]) -> (),
+        F: Fn(&mut [u8]),
     {
         let mut event: [u8; UHID_EVENT_SIZE] = InputEvent::GetReportReply { id, err, data }.into();
         fun(&mut event);


### PR DESCRIPTION
certain devices implement a crc that is calculated including data that this crate will assemble in buffer: to avoid hardcoding the uhid structure outside this crate give the user the ability to modify the assembled data packet.